### PR TITLE
Generated ogv files don't actually have vorbis

### DIFF
--- a/templates/demo.html
+++ b/templates/demo.html
@@ -28,7 +28,7 @@
                     <video autoplay loop>
                 {% endif %}
                     <source src="{{ url_for('static', filename='demo.mp4') }}" type='video/mp4'></source>
-                    <source src="{{ url_for('static', filename='demo.ogv') }}" type='video/ogg; codecs="theora,vorbis"'></source>
+                    <source src="{{ url_for('static', filename='demo.ogv') }}" type='video/ogg; codecs="theora"'></source>
                 </video>
                 <p>Filesize: 118 kB (~0.118 MB)</p>
             </div>

--- a/templates/view.html
+++ b/templates/view.html
@@ -21,7 +21,7 @@
                     {% endif %}
                 {% endif %}
                     <source src="/{{ filename }}.mp4" type='video/mp4;'>
-                    <source src="/{{ filename }}.ogv" type='video/ogg; codecs="theora, vorbis"'>
+                    <source src="/{{ filename }}.ogv" type='video/ogg; codecs="theora"'>
                 </video>
             {% else %}
             <img src="/{{ original }}" />


### PR DESCRIPTION
```
$ curl https://gifquick.net/static/demo.ogv | ffmpeg -i - -f null /dev/null
ffmpeg version 1.0.7 Copyright (c) 2000-2013 the FFmpeg developers
  built on Jul  1 2013 21:18:39 with gcc 4.7.3 (Gentoo 4.7.3 p1.0, pie-0.5.5)
  configuration: --prefix=/usr --libdir=/usr/lib64 --shlibdir=/usr/lib64 --mandir=/usr/share/man --enable-shared --cc=x86_64-pc-linux-gnu-gcc --cxx=x86_64-pc-linux-gnu-g++ --ar=x86_64-pc-linux-gnu-ar --optflags='-O2 -pipe -march=corei7 -mcx16 -msahf -mno-movbe -mno-aes -mpopcnt -mno-abm -mno-lwp -mno-fma -mno-fma4 -mno-xop -mno-bmi -mno-tbm --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=3072' --extra-cflags='-O2 -pipe -march=corei7 -mcx16 -msahf -mno-movbe -mno-aes -mpopcnt -mno-abm -mno-lwp -mno-fma -mno-fma4 -mno-xop -mno-bmi -mno-tbm --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=3072' --extra-cxxflags='-O2 -pipe -march=corei7 -mcx16 -msahf -mno-movbe -mno-aes -mpopcnt -mno-abm -mno-lwp -mno-fma -mno-fma4 -mno-xop -mno-bmi -mno-tbm --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=3072' --disable-static --enable-gpl --enable-version3 --enable-postproc --enable-avfilter --enable-avresample --disable-stripping --disable-d  libavutil      51. 73.101 / 51. 73.101
  libavcodec     54. 59.100 / 54. 59.100
  libavformat    54. 29.104 / 54. 29.104
  %   libavdevice    54.  2.101 / 54.  2.101
Total    %  libavfilter     3. 17.100 /  3. 17.100
 Received %  libswscale      2.  1.101 /  2.  1.101
 Xferd  Ave  libswresample   0. 15.100 /  0. 15.100
rage Speed    libpostproc    52.  0.100 / 52.  0.100
 Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0[ogg @ 0x1aea150] 20 bytes of comment header remain
[ogg @ 0x1aea150] truncated comment header, 1 comments not found
[ogg @ 0x1aea150] Estimating duration from bitrate, this may be inaccurate
Input #0, ogg, from 'pipe:':
  Duration: N/A, start: 0.000000, bitrate: N/A
    Stream #0:0: Video: theora, yuv420p, 384x216 [SAR 1:1 DAR 16:9], 100 tbr, 100 tbn, 100 tbc
Output #0, null, to '/dev/null':
  Metadata:
    encoder         : Lavf54.29.104
    Stream #0:0: Video: rawvideo (I420 / 0x30323449), yuv420p, 384x216 [SAR 1:1 DAR 16:9], q=2-31, 200 kb/s, 90k tbn, 100 tbc
Stream mapping:
  Stream #0:0 -> #0:0 (theora -> rawvideo)
[null @ 0x1af1c60] Encoder did not produce proper pts, making some up.
100  203k  100  203k    0     0   343k      0 --:--:-- --:--:-- --:--:--  344k
frame=  365 fps=0.0 q=0.0 Lsize=       0kB time=00:00:03.65 bitrate=   0.0kbits/s dup=244 drop=0    
video:34kB audio:0kB subtitle:0 global headers:0kB muxing overhead -100.000000%
```

I see no mention of this supposed "vorbis".
