### PR TITLE
Correction to serious page about bcrypt

### DIFF
--- a/templates/serious.html
+++ b/templates/serious.html
@@ -14,8 +14,8 @@
     <p>If you see illegal content, please press "report" on the page the content appears on.</p>
     <h2>Privacy</h2>
     <p>There is only one metric we gather about you that you are not able to turn off, which is your hashed IP address. When you upload
-    an image, we run your IP address through a hashing function and store it in our database. It is mathematically impossible to reverse
-    the hashing process, so your IP address is safe, even if our database is compromised. We couldn't share it even if we wanted to.</p>
+    an image, we run your IP address through a hashing function and store it in our database. Once hashed, it is infeasible to recover
+    the IP address, so your IP address is safe, even if our database is compromised. We couldn't share it even if we wanted to.</p>
     <p>This means that if for some reason our database were stolen or we were pressured by anyone to release information about you, we
     are unable to. However, it allows us to ban malicous users from using the site. What we can do is determine if a hash matches a given
     IP address, so we can use it as a basis for banning an anonymous user. For the technically savvy, we run IPs through bcrypt with 12


### PR DESCRIPTION
With something as predictible in format as an IP address, recovering the
original IP address from the bcrypt hash is not impossible, only
infeasible. bcrypt hashes contain the salt, digest and number of rounds
used. Using this information you can attempt a brute force of the IP
address with the same salt and number of rounds. It will take a long
time, but it can be done.

The original text of the page is accurate, however it implies that
recovering an IP address from the bcrypt hash is impossible, which is
incorrect.
