### PR TITLE
Javascript performance improvements, closes #185

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -61,9 +61,20 @@ function handleFiles(files) {
         document.getElementById('files').innerHTML = '';
         firstUpload = false;
     }
+    var timeout = 500;
     for (var i = 0; i < files.length; i++) {
         uploads++;
-        handleFile(files[i]);
+        if (i == 0)
+            handleFile(files[i]);
+        else {
+            void function(i) {
+                setTimeout(function() { 
+                    console.log(i);
+                    handleFile(files[i]);
+                }, timeout);
+            }(i);
+            timeout += 500;
+        }
     }
 }
 


### PR DESCRIPTION
Uploading a bunch of media at once isn't as painful in Firefox anymore. It schedules each file to be handled half a second apart.

@jdiez17 clear to merge.
