### PR TITLE
Add webm to converters and set as preferred source

### DIFF
--- a/mediacrush/files.py
+++ b/mediacrush/files.py
@@ -13,7 +13,7 @@ from .objects import File
 from .ratelimit import rate_limit_exceeded, rate_limit_update
 from .network import secure_ip
 
-VIDEO_EXTENSIONS = set(['gif', 'ogv', 'mp4'])
+VIDEO_EXTENSIONS = set(['gif', 'ogv', 'mp4', 'webm'])
 AUDIO_EXTENSIONS = set(['mp3', 'ogg', 'oga'])
 EXTENSIONS = set(['png', 'jpg', 'jpe', 'jpeg', 'svg']) | VIDEO_EXTENSIONS | AUDIO_EXTENSIONS
 LOOP_EXTENSIONS = set(['gif'])
@@ -62,16 +62,21 @@ class URLFile(object):
 
 processing_needed = {
     'gif': {
-        'formats': ['mp4', 'ogv'],
+        'formats': ['mp4', 'ogv', 'webm'],
         'time': 120,
     },
     'mp4': {
-        'formats': ['ogv'],
+        'formats': ['webm', 'ogv'],
+        'extras': ['png'],
+        'time': 300,
+    },
+    'webm': {
+        'formats': ['mp4', 'ogv'],
         'extras': ['png'],
         'time': 300,
     },
     'ogv': {
-        'formats': ['mp4'],
+        'formats': ['mp4', 'webm'],
         'extras': ['png'],
         'time': 300,
     },

--- a/mediacrush/worker.py
+++ b/mediacrush/worker.py
@@ -54,11 +54,12 @@ class Invocation(object):
         return TimeLimitedCommand(args)
 
 converters = {
-    'mp4': Invocation("ffmpeg -i {0} -pix_fmt yuv420p -vf scale=trunc(in_w/2)*2:trunc(in_h/2)*2 {1}.mp4"),
-    'ogv': Invocation("ffmpeg -i {0} -q 5 -pix_fmt yuv420p -acodec libvorbis {1}.ogv"),
-    'mp3': Invocation("ffmpeg -i {0} {1}.mp3"),
-    'ogg': Invocation("ffmpeg -i {0} -acodec libvorbis {1}.ogg"),
-    'png': Invocation("ffmpeg -i {0} -vframes 1 {1}.png")
+    'mp4':  Invocation("ffmpeg -i {0} -pix_fmt yuv420p -vf scale=trunc(in_w/2)*2:trunc(in_h/2)*2 {1}.mp4"),
+    'ogv':  Invocation("ffmpeg -i {0} -q 5 -pix_fmt yuv420p -acodec libvorbis {1}.ogv"),
+    'webm': Invocation("ffmpeg -i {0} -c:v libvpx -c:a libvorbis -quality good -b:v 1M -crf 5 {1}.webm"),
+    'mp3':  Invocation("ffmpeg -i {0} {1}.mp3"),
+    'ogg':  Invocation("ffmpeg -i {0} -acodec libvorbis {1}.ogg"),
+    'png':  Invocation("ffmpeg -i {0} -vframes 1 {1}.png")
 }
 
 processors = {

--- a/templates/fragments/video.html
+++ b/templates/fragments/video.html
@@ -1,5 +1,6 @@
 <div class="video">
     <video id="video-{{ filename }}" {% if autoplay and not mobile %}autoplay {% endif %}{% if loop %}loop {% endif %}>
+        <source src="/{{ filename }}.webm" type='video/webm;'>
         <source src="/{{ filename }}.mp4" type='video/mp4;'>
         <source src="/{{ filename }}.ogv" type='video/ogg; codecs="theora, vorbis"'>
     </video>


### PR DESCRIPTION
Note that we still need to convert existing videos, which is probably a
day or two of hardcore processing on the server. This simply adds all
the support required to use webm for new videos.

We can push this **after ffmpeg has been recompiled to support libvpx on
the server**. Existing videos needn't have a webm source to work at that
point - the browser will fallback to one of the other available formats.

To convert the existing videos, use a script like this:

```
#!/bin/bash
for f in *.mp4
do
    bn=$(basename "$f" ".mp4")
    if [ -e "$bn.png" ]
    then
        echo "Skipping $bn"
    else
        ffmpeg -i "$bn.mp4" -c:v libvpx -c:a libvorbis -quality good -b:v 1M -crf 5 "$bn.webm"
    fi
done
```
