### PR TITLE
Allow branding to be removed from embedded media

### DIFF
--- a/docs/mediacrush.js.md
+++ b/docs/mediacrush.js.md
@@ -43,6 +43,19 @@ If you add a div like this into the page at runtime, you can use something like 
     MediaCrush.render(document.getElementById('...')); // One item
     MediaCrush.renderAll(); // Re-discovers and renders all items on the page
 
+MediaCrush.js will preserve all #controls in the data-media attribute. For example, you might do:
+
+    <div class="mediacrush" data-media="tG6dvDt2jNcr#autoplay,loop"></div>
+
+The full list of modifiers is:
+
+* `autoplay`: Forces the media to autoplay
+* `noautoplay`: Forces the media not to autoplay
+* `loop`: Forces the media to loop
+* `noloop`: Forces the media not to loop
+* `mute`: Mutes the media by default
+* `nobrand`: Does not show MediaCrush branding in the embedded media player (doing this makes us sad, but we won't stop you)
+
 **Upload a file**
 
 Say you have this in your page somewhere:

--- a/templates/fragments/audio.css
+++ b/templates/fragments/audio.css
@@ -128,3 +128,9 @@
     top: 0;
     left: 0;
 }
+.nobrand .brand {
+    display: none;
+}
+.nobrand .controls {
+    margin-left: 0;
+}

--- a/templates/fragments/audio.js
+++ b/templates/fragments/audio.js
@@ -156,3 +156,33 @@ function pauseMedia() {
         pause(audio[i]);
     }
 }
+function mediaHashHandler(hash) {
+    var parts = hash.split(',');
+    var audio = document.getElementById('audio-{{ filename }}');
+    var loopControl = document.querySelector('.control.loop');
+    var largePlayControl = document.querySelector('.control.play.large');
+    var muteControl = document.querySelector('.control.mute');
+    for (var i = 0; i < parts.length; i++) {
+        if (parts[i] == 'loop') {
+            audio.loop = true;
+            loopControl.classList.add('enabled');
+        } else if (parts[i] == 'noloop') {
+            audio.loop = false;
+            loopControl.classList.remove('enabled');
+        } else if (parts[i] == 'autoplay') {
+            if (!mobile)
+                play(audio);
+        } else if (parts[i] == 'noautoplay') {
+            if (!mobile) {
+                largePlayControl.classList.remove('hidden');
+                pause(audio);
+            }
+        } else if (parts[i] == 'mute') {
+            audio.muted = true;
+            muteControl.classList.add('unmute');
+            muteControl.classList.remove('mute');
+        } else if (parts[i] == 'nobrand') {
+            audio.parentElement.classList.add('nobrand');
+        }
+    }
+}

--- a/templates/fragments/video.css
+++ b/templates/fragments/video.css
@@ -214,3 +214,6 @@
     top: 0;
     left: 0;
 }
+.nobrand h1.brand {
+    display: none;
+}

--- a/templates/fragments/video.js
+++ b/templates/fragments/video.js
@@ -285,6 +285,8 @@ function mediaHashHandler(hash) {
             video.muted = true;
             muteControl.classList.add('unmute');
             muteControl.classList.remove('mute');
+        } else if (parts[i] == 'nobrand') {
+            video.parentElement.classList.add('nobrand');
         }
     }
 }


### PR DESCRIPTION
This also adds playback controls via #controls to the audio player.

This change per user feedback request:

```
User feedback:
    [user agent omitted]:
        If I donate, can I embed a video without mediacrush branding?
```

We don't think you should have to donate for that.
