### PR TITLE
Move social links to top of drop box

### DIFF
--- a/styles/home-responsive.scss
+++ b/styles/home-responsive.scss
@@ -44,6 +44,15 @@
             background: url('/static/upload.png') transparent no-repeat 100px 220px;
         }
 
+        #droptext a {
+            font-size: 14pt;
+            font-weight: bold;
+
+            span {
+                font-weight: normal;
+            }
+        }
+
         #files ul {
             left: 75px;
 
@@ -102,5 +111,9 @@
 
     .container {
         width: 634px;
+    }
+
+    .social {
+        display: none;
     }
 }

--- a/styles/home.scss
+++ b/styles/home.scss
@@ -325,40 +325,28 @@
     }
 }
 
-a[href^="https://twitter.com"] {
-    display: inline-block;
-    background: url("/static/twitter.png") no-repeat;
-    width: 16px;
-    height: 16px;
+.social {
     position: relative;
-    top: 3px;
-}
+    top: 10px;
+    display: block;
+    width: 100%;
+    text-align: center;
 
-a[href^="https://pay.reddit.com"] {
-    display: inline-block;
-    width: 16px;
-    height: 16px;
-    background: url("/static/reddit.png") no-repeat;
-    position: relative;
-    top: 3px;
-}
+    a {
+        display: inline-block;
+        min-height: 16px;
+        padding-left: 18px;
+        font-size: 10pt;
+        margin-left: 5px;
 
-a[href^="https://chrome.google.com"] {
-    display: inline-block;
-    width: 16px;
-    height: 16px;
-    background: url('/static/chrome.png') no-repeat;
-    position: relative;
-    top: 3px;
-}
+        &[href^="https://twitter.com"] {
+            background: url("/static/twitter.png") no-repeat 0 1px;
+        }
 
-a[href^="https://addons.mozilla.org"] {
-    display: inline-block;
-    width: 16px;
-    height: 16px;
-    background: url('/static/firefox.png') no-repeat;
-    position: relative;
-    top: 3px;
+        &[href^="https://pay.reddit.com"] {
+            background: url("/static/reddit.png") no-repeat 0 1px;
+        }
+    }
 }
 
 @import 'home-responsive.scss'

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,6 +36,10 @@
                         MP3 OGG
                     </li>
                 </ul>
+                <div class="social">
+                    <a target="_blank" href="https://pay.reddit.com/r/MediaCrush">/r/MediaCrush</a>
+                    <a target="_blank" href="https://twitter.com/mediacru_sh">@mediacru_sh</a>
+                </div>
                 {% if notice_enabled %}
                 <div id="notice">
                     <div>{{ notice_text }}</div>
@@ -51,8 +55,6 @@
         </div>
         <div class="small">
             <ul class="inline">
-                <li><a href="https://twitter.com/mediacru_sh" target="_blank" title="Follow @mediacru_sh on Twitter!"></a></li>
-                <li><a href="https://pay.reddit.com/r/mediacrush" target="_blank" title="Subscribe to /r/mediacrush on Reddit!"></a></li>
                 <li><a href="/serious">Terms & Privacy</a></li>
                 <li><a href="/docs">Developers</a></li>
                 <li><a href="mailto:support@mediacru.sh">Help</a></li>


### PR DESCRIPTION
This makes the /r/MediaCrush and @mediacru_sh links more apparent, but
maybe a little more intrusive. I think it looks fine.

This commit also makes minor responsiveness improvements to the appearance of the drop
text on smaller layouts (namely by preventing the "Drag and drop or click to
upload" text from wrapping).

Closes #435 

![2013-12-04_00 20 27](https://f.cloud.github.com/assets/1310872/1671555/23c84368-5cbd-11e3-8e4a-a3a91fe1c25a.png)
