### PR TITLE
Update dependencies for python 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ gunicorn==17.5
 itsdangerous==0.22
 mandrill==1.0.42
 pep8==1.4.6
-py-bcrypt==0.3
+py-bcrypt==0.4
 pyScss==1.2.0.post3
 redis==2.7.6
 requests==2.0.0


### PR DESCRIPTION
wsgiref is a default package in python 2 environments and breaks python 3 setup.

py-bcrypt is safely upgradeable to 0.4.
