### PR TITLE
Preload server-side files for new uploads

### DIFF
--- a/scripts/home-files.coffee
+++ b/scripts/home-files.coffee
@@ -135,6 +135,7 @@ class MediaFile
         largeLink.href = link.href = "/#{@hash}"
         link.classList.remove('hidden')
         largeLink.classList.remove('hidden')
+        @preload()
         if @isUserOwned
             deleteLink = @preview.querySelector('.delete')
             deleteLink.href = "/api/#{@hash}/delete"
@@ -154,5 +155,19 @@ class MediaFile
                 )
             , false)
             deleteLink.classList.remove('hidden')
+
+    preload: ->
+        for file in @blob.files
+            if file.type.startsWith('image/') and file.type != 'image/gif'
+                _ = document.createElement('img')
+                _.src = file.file
+            else if file.type.startsWith('video/')
+                _ = document.createElement('video')
+                _.preload = 'auto'
+                _.src = file.file
+            else if file.type.startsWith('audio/')
+                _ = document.createElement('audio')
+                _.preload = 'auto'
+                _.src = file.file
         
 window.MediaFile = MediaFile

--- a/scripts/home.coffee
+++ b/scripts/home.coffee
@@ -329,6 +329,7 @@ fileStatusChanged = (e) ->
     if e.file? and e.file.flags?
         uploadedFiles[e.hash].setFlags(e.file.flags)
     if e.status in ['ready', 'done']
+        uploadedFiles[e.hash].blob = e.file
         finish(uploadedFiles[e.hash])
 
 finish = (file) ->


### PR DESCRIPTION
This makes the site appear to perform better because we take advantage of the time the user spends looking at the home page after each upload to preload the media on the subsequent view page.

@jdiez17 clear to merge
