### PR TITLE
Switch load for DOMContentReady where reasonable

### DIFF
--- a/scripts/home.coffee
+++ b/scripts/home.coffee
@@ -2,7 +2,7 @@ worker = new Worker('/static/worker.js')
 albumAttached = false
 maxConcurrentUploads = 3
 
-window.addEventListener('load', ->
+window.addEventListener('DOMContentReady', ->
     window.addEventListener('dragenter', dragNop, false)
     window.addEventListener('dragleave', dragNop, false)
     window.addEventListener('dragover', dragNop, false)

--- a/scripts/mine.coffee
+++ b/scripts/mine.coffee
@@ -3,7 +3,7 @@ itemsToLoad = []
 itemsPerPage = 10
 paginationLimit = 4
 
-window.addEventListener('load', ->
+window.addEventListener('DOMContentReady', ->
     historyEnabled = document.getElementById('history-toggle')
     disabledText = document.getElementById('disabledText')
     if not UserHistory.getHistoryEnabled()

--- a/scripts/view.coffee
+++ b/scripts/view.coffee
@@ -1,4 +1,4 @@
-window.addEventListener('load', ->
+window.addEventListener('DOMContentReady', ->
     inputs = document.querySelectorAll('input.selectall')
     input.addEventListener('mouseenter', (e) ->
         e.target.focus()


### PR DESCRIPTION
This means that as soon as the DOM is loaded, we start wiring up JS. Then we aren't waiting on images to finish loading or anything.
