### PR TITLE
Fix Twitter Cards

### DIFF
--- a/mediacrush/app.py
+++ b/mediacrush/app.py
@@ -7,12 +7,12 @@ import os
 import traceback
 import subprocess
 
-from .views import HookView, APIView, MediaView, DocsView
-from .config import _cfg, _cfgi
-from .files import extension, get_mimetype
-from .views.media import render_media
-from .share import share
-from .network import is_tor, get_ip
+from mediacrush.views import HookView, APIView, MediaView, DocsView
+from mediacrush.config import _cfg, _cfgi
+from mediacrush.files import extension, get_mimetype, media_url
+from mediacrush.views.media import render_media
+from mediacrush.share import share
+from mediacrush.network import is_tor, get_ip
 
 app = Flask(__name__)
 app.jinja_env.cache = None
@@ -77,7 +77,8 @@ def inject():
         'get_mimetype': get_mimetype,
         'cdn': cdn,
         'is_tor': is_tor(),
-        'ip': get_ip()
+        'ip': get_ip(),
+        'media_url': media_url,
     }
 
 @app.route("/")

--- a/mediacrush/files.py
+++ b/mediacrush/files.py
@@ -76,8 +76,12 @@ def get_hash(f):
     f.seek(0)
     return hashlib.md5(f.read()).digest()
 
-def media_url(f):
-    return '/%s' % f
+def media_url(f, absolute=True):
+    cdn = _cfg("cdn")
+    domain = _cfg("domain")
+    base = _cfg("protocol") + "://" + domain if len(cdn) == 0 else cdn
+
+    return '%s/%s' % (base, f) if absolute else '/%s' % f
 
 def file_length(f):
     f.seek(0, 2)

--- a/mediacrush/views/api.py
+++ b/mediacrush/views/api.py
@@ -23,7 +23,7 @@ def _file_object(f):
     if f.metadata and f.metadata != 'None':
         metadata = json.loads(f.metadata)
     ret = {
-        'original': media_url(f.original),
+        'original': media_url(f.original, absolute=False),
         'type': mimetype,
         'blob_type': normalise_processor(f.processor),
         'hash': f.hash,
@@ -51,8 +51,8 @@ def _file_object(f):
 def _file_entry(f, mimetype=None):
     return {
         'type': mimetype if mimetype else get_mimetype(f),
-        'file': media_url(f),
-        'url': _cfg("cdn") + media_url(f)
+        'file': media_url(f, absolute=False), # This silliness will be fixed in API 2
+        'url': media_url(f)
     }
 
 def _album_object(a):

--- a/templates/view.html
+++ b/templates/view.html
@@ -24,20 +24,20 @@
     <meta property="og:site_name" content="MediaCrush" />
     {% if processor.startswith("video") %}
         {# Generated thumbnail #}
-        <meta property="og:image" content="https://mediacru.sh/{{ filename }}.jpg" />
+        <meta property="og:image" content="{{ media_url(filename) }}.jpg" />
         <meta property="twitter:card" content="player" />
         <meta property="twitter:title" content="MediaCrush" />
         <meta property="twitter:description" content="A video shared with MediaCrush." />
         <meta property="twitter:player" content="{{ share('frame', filename) }}" />
         <meta property="twitter:player:width" content="640" />
         <meta property="twitter:player:height" content="360" />
-        <meta property="twitter:image" content="/{{ filename }}.jpg">
+        <meta property="twitter:image" content="{{ media_url(filename) }}.jpg">
     {% elif processor.startswith("audio") %}
         <meta property="og:image" content="/static/audio.png" />
     {% else %}
-        <meta property="og:image" content="https://mediacru.sh/{{ original }}" />
+        <meta property="og:image" content="{{ media_url(original) }}" />
         <meta name="twitter:card" content="photo">
-        <meta name="twitter:image" content="/{{ original }}">
+        <meta name="twitter:image" content="{{ media_url(original) }}">
     {% endif %}
 {% endblock %}
 {% block content %}


### PR DESCRIPTION
Closes #545.

Note that video links (like the tweet linked in the issue) will still not work because Twitter has not approved our domain for video yet. Nothing we can do, afaik.

@SirCmpwn, ready to merge.
