### PR TITLE
Avoid downloading when Content-Length is bigger than MAX_SIZE

### DIFF
--- a/mediacrush/files.py
+++ b/mediacrush/files.py
@@ -52,8 +52,13 @@ class URLFile(object):
 
     def download(self, url):
         r = requests.get(url, stream=True)
+        if r.headers["content-length"] > MAX_SIZE:
+            raise FileTooBig("The file was larger than 50 MB")
+
         for i, chunk in enumerate(r.iter_content(chunk_size=1024)):
             if i > MAX_SIZE / 1024:
+                # Evil servers may send more than Content-Length bytes
+                # As of 54541a9, python-requests keeps reading indefinitely
                 raise FileTooBig("The file was larger than 50 MB")
             self.f.write(chunk)
             self.f.flush()


### PR DESCRIPTION
Continued from 60164a9. With this, we don't need to download anything
if we are dealing with a nice server that properly sets Content-Length.

Unfortunately, we still have to check during download as python-requests
does not abstract that bit away.
