### PR TITLE
Fix for a race condition in process_file(). 

### DIFF
--- a/mediacrush/tasks.py
+++ b/mediacrush/tasks.py
@@ -64,10 +64,12 @@ def cleanup(results, path, h):
 
 @app.task
 def process_file(path, h, ignore_limit):
-    f = File.from_hash(h)
-    if f == None: # Redis hasn't caught up yet.
-        time.sleep(2)
+    t = time.time() + 2
+    while True:
         f = File.from_hash(h)
+        if f or time.time() > t:
+            break
+        time.sleep(0.05) # Wait for Redis to catch up
 
     try:
         result = detect(path)


### PR DESCRIPTION
If a hash was not in Redis when process_file() was executed, processing would fail without deleting the hash from the database.

It may be better to use a loop on this (while f == None) but I figure infinite loops should be the author's domain. As it is, if the hash is not in Redis after 2 seconds, the failure mode will be as before: the processing will fail and _then_ the hash will be added to the database, without any processing. This will result in the "Unable to detect file type" error page whenever that file is uploaded.
